### PR TITLE
Release announcement - 2.4.5-p1

### DIFF
--- a/src/pages/blog/20221011-new-magento-release.md
+++ b/src/pages/blog/20221011-new-magento-release.md
@@ -1,0 +1,16 @@
+---
+layout: '@/layouts/post.astro'
+date: 2022-10-11
+title: Magento 2.4.5-p1 release
+description: Now available on mirror.mage-os.org
+---
+
+Adobe has released updates to Magento Open Source today, versions 2.4.5-p1 and 2.4.4-p2.
+
+Those same updates are now also available if you're using our Magento mirror composer repository, `mirror.mage-os.org`. Our validation has confirmed the mirror releases are installable and match the official releases.
+
+Thanks to Vinai Kopp and Damien Retzinger for managing the release process.
+
+If you're not yet using the Mage-OS Magento mirror, you can do that today by swapping `repo.magento.com` to `mirror.mage-os.org` in your composer.json (unless you require any Magento Marketplace packages). This is a public repository, built by our independent open source build process from the Magento 2 source code. For more info on the Mage-OS nightly and mirror repositories, see: https://mage-os.org/distribution
+
+We have plans to launch the Mage-OS Distribution and start accepting pull requests by the end of this year. Stay tuned for more!


### PR DESCRIPTION
Tentative site update for the 2.4.5-p1 and 2.4.4-p2 releases being available on our Magento mirror.

Note I started a new filename convention to get away from the arbitrary 'week-#' URLs. I figure a date prefix is less arbitrary and will help with organizing the updates over time.